### PR TITLE
Fixed bugs with token '<' and [object Object]

### DIFF
--- a/jqueryupload.js
+++ b/jqueryupload.js
@@ -73,7 +73,7 @@
 	e.attr('name', param.name);
 	e.attr('value', param.value);
 	return e;
-    }).join('');
+    });
   }
 
   function param(data) {
@@ -115,7 +115,7 @@
     if ($.isXMLDoc(contents) || contents.XMLDocument) {
       return contents.XMLDocument || contents;
     }
-    data = $(contents).find('body').html();
+    data = $(contents).find('body').text();
     switch (type) {
     case 'xml':
       data = parseXml(data);


### PR DESCRIPTION
https://github.com/Ruxton92/jqueryupload/commit/d213fc52e1e767c9fd9815220a26a43bba8ea452#diff-64a85363f76103f7a8596eaeed5e8e18L76
There was a trouble with .join: createInputs() returns [object Object], not array.
https://github.com/Ruxton92/jqueryupload/commit/d213fc52e1e767c9fd9815220a26a43bba8ea452#diff-64a85363f76103f7a8596eaeed5e8e18L118
$(contents).find('body').html() return response message wrapped with html, so it can't be parsed as JSON.
